### PR TITLE
Update deps and fix deprecations for SDK 36

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,20 @@
 buildscript {
-    ext.kotlin_version = '1.7.20'
-    ext.core_ktx_version = '1.9.0'
+    ext.kotlin_version = '2.2.0'
+    ext.core_ktx_version = '1.12.0'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.2'
+        classpath 'com.android.tools.build:gradle:8.13.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
 ext {
     sdk = [
-        compileSdk: 33,
-        targetSdk : 33,
+        compileSdk: 36,
+        targetSdk : 36,
         minSdk    : 21
     ]
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Oct 22 10:52:59 IST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/imagepicker/build.gradle
+++ b/imagepicker/build.gradle
@@ -33,6 +33,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     lint {
         abortOnError false
     }
@@ -61,7 +65,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.ZupersoftSolutions'
             artifactId = 'android-image-picker'
-            version = '3.1.4'
+            version = '3.2.0'
 
             afterEvaluate {
                 from components.release

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerActivity.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerActivity.kt
@@ -4,14 +4,19 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.graphics.PorterDuff
+import android.os.Build
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.esafirm.imagepicker.R
 import com.esafirm.imagepicker.features.cameraonly.CameraOnlyConfig
 import com.esafirm.imagepicker.helper.ConfigUtils
@@ -29,11 +34,21 @@ class ImagePickerActivity : AppCompatActivity(), ImagePickerInteractionListener 
     private lateinit var imagePickerFragment: ImagePickerFragment
 
     private val config: ImagePickerConfig? by lazy {
-        intent.extras!!.getParcelable(ImagePickerConfig::class.java.simpleName)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.extras!!.getParcelable(ImagePickerConfig::class.java.simpleName, ImagePickerConfig::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            intent.extras!!.getParcelable(ImagePickerConfig::class.java.simpleName)
+        }
     }
 
     private val cameraOnlyConfig: CameraOnlyConfig? by lazy {
-        intent.extras?.getParcelable(CameraOnlyConfig::class.java.simpleName)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.extras?.getParcelable(CameraOnlyConfig::class.java.simpleName, CameraOnlyConfig::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            intent.extras?.getParcelable(CameraOnlyConfig::class.java.simpleName)
+        }
     }
 
     private val isCameraOnly by lazy { cameraOnlyConfig != null }
@@ -80,6 +95,8 @@ class ImagePickerActivity : AppCompatActivity(), ImagePickerInteractionListener 
         setTheme(currentConfig.theme)
         setContentView(R.layout.ef_activity_image_picker)
         setupView(currentConfig)
+        setupEdgeToEdge()
+        setupBackNavigation()
 
         if (savedInstanceState != null) {
             // The fragment has been restored.
@@ -118,7 +135,7 @@ class ImagePickerActivity : AppCompatActivity(), ImagePickerInteractionListener 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         val id = item.itemId
         if (id == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
         if (id == R.id.menu_done) {
@@ -132,13 +149,30 @@ class ImagePickerActivity : AppCompatActivity(), ImagePickerInteractionListener 
         return super.onOptionsItemSelected(item)
     }
 
-    override fun onBackPressed() {
-        if (this::imagePickerFragment.isInitialized) {
-            if (!imagePickerFragment.handleBack()) {
-                super.onBackPressed()
+    private fun setupBackNavigation() {
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (::imagePickerFragment.isInitialized && imagePickerFragment.handleBack()) {
+                    return
+                }
+                isEnabled = false
+                onBackPressedDispatcher.onBackPressed()
             }
-        } else {
-            super.onBackPressed()
+        })
+    }
+
+    private fun setupEdgeToEdge() {
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        val main = findViewById<View>(R.id.main)
+        ViewCompat.setOnApplyWindowInsetsListener(main) { _, insets ->
+            val statusBarInsets = insets.getInsets(WindowInsetsCompat.Type.statusBars())
+            val navBarInsets = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
+            toolbar?.setPadding(0, statusBarInsets.top, 0, 0)
+            toolbar?.layoutParams?.height = resources.getDimensionPixelSize(
+                androidx.appcompat.R.dimen.abc_action_bar_default_height_material
+            ) + statusBarInsets.top
+            main.setPadding(0, 0, 0, navBarInsets.bottom)
+            insets
         }
     }
 

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerActivity.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerActivity.kt
@@ -16,6 +16,7 @@ import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import com.esafirm.imagepicker.R
 import com.esafirm.imagepicker.features.cameraonly.CameraOnlyConfig
@@ -162,15 +163,20 @@ class ImagePickerActivity : AppCompatActivity(), ImagePickerInteractionListener 
     }
 
     private fun setupEdgeToEdge() {
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
         val main = findViewById<View>(R.id.main)
         ViewCompat.setOnApplyWindowInsetsListener(main) { _, insets ->
             val statusBarInsets = insets.getInsets(WindowInsetsCompat.Type.statusBars())
             val navBarInsets = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
-            toolbar?.setPadding(0, statusBarInsets.top, 0, 0)
-            toolbar?.layoutParams?.height = resources.getDimensionPixelSize(
-                androidx.appcompat.R.dimen.abc_action_bar_default_height_material
-            ) + statusBarInsets.top
+            toolbar?.let {
+                it.setPadding(0, statusBarInsets.top, 0, 0)
+                it.layoutParams = it.layoutParams.apply {
+                    height = resources.getDimensionPixelSize(
+                        androidx.appcompat.R.dimen.abc_action_bar_default_height_material
+                    ) + statusBarInsets.top
+                }
+            }
             main.setPadding(0, 0, 0, navBarInsets.bottom)
             insets
         }

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.kt
@@ -44,7 +44,12 @@ class ImagePickerFragment : Fragment() {
     }
 
     private val config: ImagePickerConfig by lazy {
-        requireArguments().getParcelable(ImagePickerConfig::class.java.simpleName)!!
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            requireArguments().getParcelable(ImagePickerConfig::class.java.simpleName, ImagePickerConfig::class.java)!!
+        } else {
+            @Suppress("DEPRECATION")
+            requireArguments().getParcelable(ImagePickerConfig::class.java.simpleName)!!
+        }
     }
 
     private val permissions: Array<String> by lazy {
@@ -111,7 +116,12 @@ class ImagePickerFragment : Fragment() {
         val selectedImages = if (savedInstanceState == null) {
             config.selectedImages
         } else {
-            savedInstanceState.getParcelableArrayList(STATE_KEY_SELECTED_IMAGES)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                savedInstanceState.getParcelableArrayList(STATE_KEY_SELECTED_IMAGES, Image::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                savedInstanceState.getParcelableArrayList(STATE_KEY_SELECTED_IMAGES)
+            }
         }
 
         val recyclerViewManager = createRecyclerViewManager(
@@ -122,7 +132,13 @@ class ImagePickerFragment : Fragment() {
         )
 
         if (savedInstanceState != null) {
-            recyclerViewManager.onRestoreState(savedInstanceState.getParcelable(STATE_KEY_RECYCLER))
+            val recyclerState = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                savedInstanceState.getParcelable(STATE_KEY_RECYCLER, Parcelable::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                savedInstanceState.getParcelable(STATE_KEY_RECYCLER)
+            }
+            recyclerViewManager.onRestoreState(recyclerState)
         }
 
         interactionListener.selectionChanged(recyclerViewManager.selectedImages)

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/helper/LocaleManager.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/helper/LocaleManager.kt
@@ -34,7 +34,7 @@ object LocaleManager {
             newLocaleLanguage.length == 5 -> {
                 locale = Locale(
                     newLocaleLanguage.substring(0, 2),
-                    newLocaleLanguage.substring(3, 5).toUpperCase(Locale.getDefault())
+                    newLocaleLanguage.substring(3, 5).uppercase(Locale.getDefault())
                 )
                 locale
             }

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/helper/diff/ValueComparison.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/helper/diff/ValueComparison.kt
@@ -10,7 +10,7 @@ class DefaultValueComparison<T> : ValueComparison<T> {
     }
 }
 
-class SimpleDiffUtilCallBack<T>(
+class SimpleDiffUtilCallBack<T : Any>(
     private val areItemTheSame: ValueComparison<T> = DefaultValueComparison(),
     private val areContentTheSame: ValueComparison<T> = DefaultValueComparison()
 ) : DiffUtil.ItemCallback<T>() {

--- a/sample/src/main/java/com/esafirm/sample/MainActivity.kt
+++ b/sample/src/main/java/com/esafirm/sample/MainActivity.kt
@@ -6,6 +6,8 @@ import android.graphics.Color
 import android.os.Bundle
 import android.os.Environment
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.esafirm.imagepicker.features.*
 import com.esafirm.imagepicker.features.cameraonly.CameraOnlyConfig
 import com.esafirm.imagepicker.model.Image
@@ -28,6 +30,14 @@ class MainActivity : AppCompatActivity() {
 
         binding = ActivityMainBinding.inflate(layoutInflater).also {
             setContentView(it.root)
+        }
+        setSupportActionBar(binding.toolbar)
+        ViewCompat.setOnApplyWindowInsetsListener(binding.main) { view, insets ->
+            val systemBars = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+            )
+            view.setPadding(0, systemBars.top, 0, systemBars.bottom)
+            insets
         }
         setupButtons()
     }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -16,8 +16,8 @@
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:paddingLeft="@dimen/activity_horizontal_margin"
-        android:paddingRight="@dimen/activity_horizontal_margin">
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:paddingEnd="@dimen/activity_horizontal_margin">
 
     <ScrollView
         android:layout_width="match_parent"

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -1,12 +1,23 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:orientation="vertical"
     tools:context=".MainActivity">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin">
 
     <ScrollView
         android:layout_width="match_parent"
@@ -124,4 +135,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-</RelativeLayout>
+    </RelativeLayout>
+
+</LinearLayout>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
 
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="colorPrimary">#607D8B</item>
         <item name="colorPrimaryDark">#455A64</item>
         <item name="colorAccent">@color/ef_colorAccent</item>


### PR DESCRIPTION
## Summary
- Upgrade AGP to 8.13.2, Kotlin to 2.2.0, Gradle to 8.13, compileSdk/targetSdk to 36
- Fix deprecated `getParcelable`/`getParcelableArrayList` calls with version-gated (TIRAMISU+) alternatives
- Replace deprecated `onBackPressed` override with `OnBackPressedCallback`
- Add edge-to-edge window inset handling for status/navigation bars
- Fix Kotlin warnings in `LocaleManager` (`toUpperCase` → `uppercase`) and `ValueComparison` (nullable upper bound)

## Test plan
- [x] Built and installed on Pixel 10 Pro XL (physical device)
- [x] Built and installed on emulator
- [ ] Verify image picker opens and selects images correctly
- [ ] Verify camera-only mode works
- [ ] Verify back navigation behaves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build toolchain and SDK targets; bumped library release and compilation targets; set Kotlin JVM target to 1.8

* **Bug Fixes**
  * Improved Android 13+ parcelable handling for better runtime compatibility
  * Reworked back navigation to use the system back dispatcher

* **Style / UI**
  * Added edge-to-edge/window-inset handling and toolbar integration; adjusted sample layout and theme for insets and toolbar
<!-- end of auto-generated comment: release notes by coderabbit.ai -->